### PR TITLE
Write catalog versions explicitly for Dependabot compatibility

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,12 +3,12 @@ packages:
   - "packages/*"
 catalogs:
   samchon:
-    nestia: &nestia ^12.0.0-rc.4
-    "@nestia/benchmark": *nestia
-    "@nestia/core": *nestia
-    "@nestia/e2e": *nestia
-    "@nestia/fetcher": *nestia
-    "@nestia/sdk": *nestia
+    "@nestia/benchmark": ^12.0.0-rc.4
+    "@nestia/core": ^12.0.0-rc.4
+    "@nestia/e2e": ^12.0.0-rc.4
+    "@nestia/fetcher": ^12.0.0-rc.4
+    "@nestia/sdk": ^12.0.0-rc.4
+    nestia: ^12.0.0-rc.4
     tgrid: ^1.2.1
     tstl: ^3.0.0
     typia: ^13.0.1
@@ -18,8 +18,8 @@ catalogs:
     rimraf: ^6.1.3
     uuid: ^13.0.0
   typescript:
-    ttsc: &ttsc ^0.18.2
-    "@ttsc/lint": *ttsc
-    "@ttsc/paths": *ttsc
-    "@ttsc/unplugin": *ttsc
+    "@ttsc/lint": ^0.18.2
+    "@ttsc/paths": ^0.18.2
+    "@ttsc/unplugin": ^0.18.2
+    ttsc: ^0.18.2
     typescript: ^7.0.2


### PR DESCRIPTION
## Summary

Dependabot's pnpm workspace updater ([`pnpm_workspace_updater.rb`](https://github.com/dependabot/dependabot-core/blob/main/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_workspace_updater.rb)) locates catalog entries in `pnpm-workspace.yaml` with a plain `name: version` regex. Entries expressed through YAML anchors/aliases (`nestia: &nestia ...`, `"@nestia/core": *nestia`) can never be matched, so the `samchon` and `typescript` Dependabot groups would silently stop receiving catalog version updates after the monorepo restructure (#632).

This spells out every catalog version explicitly — the same style as [samchon/typia](https://github.com/samchon/typia)'s `pnpm-workspace.yaml`. The grouped Dependabot updates (`Samchon`, `TypeScript` groups in `.github/dependabot.yml`) keep the related packages in lockstep, which is what the anchors were for.

## Notes

- Purely representational: the resolved specifiers are identical, so `pnpm-lock.yaml` is unchanged.
- The rest of the Dependabot setup already fits the new workspace: `directory: '/'` covers the workspace root where the catalogs and lockfile live, `@ttsc/*` in the allow list covers the newly added `@ttsc/unplugin`, and the automerge workflow already watches `pnpm-workspace.yaml` and both package manifests.
- `rolldown` (and `rimraf`/`uuid`/`tinyglobby`) stay outside the allow list, consistent with the existing curation — `rollup` was not tracked before either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVycM68fvA2MnYYRnaY2ga