### PR TITLE
Resolve the api package's self-import through a workspace devDependency

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -37,8 +37,8 @@
     "typia": "catalog:samchon"
   },
   "devDependencies": {
+    "@ORGANIZATION/PROJECT-api": "workspace:*",
     "@ttsc/lint": "catalog:typescript",
-    "@ttsc/paths": "catalog:typescript",
     "rolldown": "catalog:rolldown",
     "ttsc": "catalog:typescript",
     "typescript": "catalog:typescript"

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -5,9 +5,6 @@
     "stripInternal": true,
     "outDir": "lib",
     "rootDir": "src",
-    "paths": {
-      "@ORGANIZATION/PROJECT-api": ["./src"]
-    },
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,10 +92,10 @@ importers:
         specifier: catalog:samchon
         version: 13.0.1(@types/node@24.13.3)
     devDependencies:
+      '@ORGANIZATION/PROJECT-api':
+        specifier: workspace:*
+        version: 'link:'
       '@ttsc/lint':
-        specifier: catalog:typescript
-        version: 0.18.2
-      '@ttsc/paths':
         specifier: catalog:typescript
         version: 0.18.2
       rolldown:


### PR DESCRIPTION
## Summary

The SDK generated by nestia imports its own package name (`@ORGANIZATION/PROJECT-api`) for the DTO types. Until now that self-import resolved through a tsconfig `paths` alias plus an `@ttsc/paths` devDependency that was never actually registered as a plugin anywhere.

The rolldown build never saw that alias: `@ttsc/unplugin` compiled the self-import as `any`, so typia emitted stub validators and the published `.mjs` twins shipped `random()` / `simulate()` bodies that just returned `"any type used..."` (456 lines / 13.7 kB instead of the correct 909 lines / 35 kB with the full typia validators).

This PR drops the alias and `@ttsc/paths`, and lets the package depend on itself through `workspace:*` instead. pnpm links the package into its own `node_modules`, so every toolchain (ttsc, `@ttsc/unplugin`, editors) resolves the self-import the ordinary way, and the ESM build now carries the same full validators as the CJS build.

## Publish safety (verified with a packed tarball)

- `pnpm pack` rewrites the self-entry to a concrete version (`"@ORGANIZATION/PROJECT-api": "0.1.0"`) inside `devDependencies`, which consumers never install — no cycle, no install-time effect.
- The bare self-import kept in the published `lib/**/*.d.ts` resolves back to the package itself via ordinary `node_modules` lookup: `tsc --strict --moduleResolution nodenext` type-check passes in an external consumer project.
- ESM `import` and CJS `require` of the installed tarball both work, and `api.functional.bbs.articles.index.random()` returns real random data — the path that was previously broken.
- Backend e2e tests pass; the backend resolves the api package through its own workspace dependency and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVycM68fvA2MnYYRnaY2ga